### PR TITLE
New libcct version + streaming downloads in Chrome

### DIFF
--- a/app.js
+++ b/app.js
@@ -81,7 +81,6 @@ $(document).ready(function() {
     }
 
     cct.log.setLogLevel(cct.log.INFO);
-    cct.log.setLogLevel('file-ref', cct.log.ALL);
     cct.log.color = true;
 
     var client = new cct.Client({

--- a/app.js
+++ b/app.js
@@ -66,6 +66,10 @@ function hideButton() {
     $('.box__button').hide();
 }
 
+window.addEventListener('hashchange', function () {
+    location.reload()
+})
+
 $(document).ready(function() {
     var isAdvancedUpload = function() {
         var div = document.createElement('div');
@@ -91,8 +95,8 @@ $(document).ready(function() {
 
     var link;
     var droppedFiles = false;
-    var roomId = window.location.hash.slice(1);
-    var isInitiator = !roomId;
+    var localRoomId = window.location.hash.slice(1);
+    var isInitiator = !localRoomId;
 
     if (isInitiator) {
         var box = $('.box');
@@ -134,16 +138,13 @@ $(document).ready(function() {
         });
     } else {
         hideInstructions();
-        start(client, roomId)
+        start(client, localRoomId)
         showConnecting()
-        window.addEventListener('hashchange', function () {
-            location.reload()
-        })
     }
 
-    function start(client, roomId) {
+    function start(client, localRoomId) {
         return connectionPromise
-            .then(enterRoom.bind(0, roomId))
+            .then(enterRoom.bind(0, localRoomId))
             .then(setupCall)
             .catch(function (error) {
                 console.log('Could not connect to server:', error)
@@ -157,7 +158,7 @@ $(document).ready(function() {
         if (isInitiator) {
             call = room.startPassiveCall()
             $('.box__instructions').text('Share the following link with a friend:');
-            $('.box__share').show(400).text(window.location.href + '#' + room.id);
+            $('.box__share').show(400).text(window.location.href + '#' + room.id.slice(1).split(':')[0]);
         } else {
             let creator = room.state('m.room.create').get().creator
             call = room.startCall(creator)

--- a/app.js
+++ b/app.js
@@ -28,6 +28,7 @@ function hideInstructions() {
     $('.box__instructions').hide();
     $('.box__share').hide();
     hideBox();
+    hideButton();
 }
 
 function showProgress() {
@@ -51,12 +52,24 @@ function isTouchDevice() {
     return (('ontouchstart' in window) || (navigator.MaxTouchPoints > 0) || (navigator.msMaxTouchPoints > 0));
 }
 
+function showButton() {
+    $('.box__button').show();
+}
+
+function hideButton() {
+    $('.box__button').hide();
+}
+
 $(document).ready(function() {
 
     var isAdvancedUpload = function() {
         var div = document.createElement('div');
         return (('draggable' in div) || ('ondragstart' in div && 'ondrop' in div)) && 'FormData' in window && 'FileReader' in window;
     }();
+
+    if (isTouchDevice()) {
+            showButton();
+    }
 
     if (!isAdvancedUpload) {
         alert('Your browser does not support drag-n-drop');
@@ -201,6 +214,9 @@ $(document).ready(function() {
         client: client,
     });
 
+    var fileSelector = $('<input type="file" multiple="">');
+
+
     // Check if I was invited.
     isInitiator = !hash;
 
@@ -230,6 +246,28 @@ $(document).ready(function() {
                     cct.log.error('error', error);
                     logError('Something went wrong');
                 });
+        });
+        var button = $('.box__button');
+        button.on('click', function(e) {
+            fileSelector.click();
+        });
+        fileSelector.on('change', function(e) {
+            droppedFiles = e.target.files;
+
+            if (droppedFiles.length > 0) {
+                peer.start()
+                .then(setupListeners)
+                .then(function () {
+                    link = window.location.href;
+                    hideButton();
+                    $('.box__instructions').text('Share the following link with a friend:');
+                    $('.box__share').show(400).text(link);
+                })
+                .catch(function (error) {
+                    cct.log.error('error', error);
+                    logError('Something went wrong');
+                });
+            }
         });
     } else {
         hideInstructions();

--- a/app.js
+++ b/app.js
@@ -16,7 +16,7 @@
 
 function showConnecting() {
     $('.box__instructions').text('Connecting...');
-    hideBox()
+    hideBox();
     hideButton();
 }
 
@@ -121,14 +121,14 @@ $(document).ready(function() {
             fileSelector.click();
         });
         fileSelector.on('change', function(e) {
-            onFiles(e.target.files)
+            onFiles(e.target.files);
         });
 
         function onFiles(files) {
             if (!droppedFiles) {
-                droppedFiles = files
-                start(client)
-                showConnecting()
+                droppedFiles = files;
+                start(client);
+                showConnecting();
             }
         }
 
@@ -138,8 +138,8 @@ $(document).ready(function() {
         });
     } else {
         hideInstructions();
-        start(client, localRoomId)
-        showConnecting()
+        start(client, localRoomId);
+        showConnecting();
     }
 
     function start(client, localRoomId) {
@@ -154,14 +154,14 @@ $(document).ready(function() {
 
     function setupCall(room) {
         console.log('Setting up call');
-        var call
+        var call;
         if (isInitiator) {
-            call = room.startPassiveCall()
+            call = room.startPassiveCall();
             $('.box__instructions').text('Share the following link with a friend:');
             $('.box__share').show(400).text(window.location.href + '#' + room.id.slice(1).split(':')[0]);
         } else {
-            let creator = room.state('m.room.create').get().creator
-            call = room.startCall(creator)
+            let creator = room.state('m.room.create').get().creator;
+            call = room.startCall(creator);
         }
 
         // for easy debugging
@@ -174,13 +174,13 @@ $(document).ready(function() {
         if (isInitiator) {
             handleLocalFiles(fileShare, droppedFiles);
         } else {
-            handleRemoteFiles(fileShare)
+            handleRemoteFiles(fileShare);
         }
 
         call.on('connected', showProgress);
 
-        let status = $('#isConnected')
-        status.show()
+        let status = $('#isConnected');
+        status.show();
         call.on('connectionState', connectionState => {
             if (connectionState === 'connected') {
                 status.text('Connected');
@@ -197,7 +197,7 @@ $(document).ready(function() {
 
     function handleLocalFiles(fileShare, files) {
         var fileCount = files.length;
-        var transferred = 0
+        var transferred = 0;
 
         for (var i = 0; i < fileCount; i++) {
             var fileRef = cct.FileRef.fromFile(files[i]);
@@ -205,11 +205,11 @@ $(document).ready(function() {
 
             fileRef.on('transfer', function (transfer) {
                 console.log('Transfer to ' + transfer.peer.id);
-                showProgressBar(transfer, transfer.once('end'))
+                showProgressBar(transfer, transfer.once('end'));
 
                 transfer.on('done', function () {
                     console.log('Transfer to ' + transfer.peer.id + ' completed');
-                    transferred += 1
+                    transferred += 1;
                     if (transferred === fileCount) {
                         showSuccess();
                     }
@@ -224,28 +224,28 @@ $(document).ready(function() {
     }
 
     function handleRemoteFiles(fileShare) {
-        var downloadQueue
+        var downloadQueue;
 
         fileShare.on('update', function (update) {
             var fileRef = update.value;
-            console.log('fileRef: ', fileRef)
+            console.log('fileRef: ', fileRef);
             if (downloadQueue) {
                 downloadQueue.unshift(fileRef);
             } else {
-                downloadQueue = [fileRef]
+                downloadQueue = [fileRef];
                 processQueue();
             }
         })
 
         function processQueue() {
-            console.log('downloadQueue: ', downloadQueue)
+            console.log('downloadQueue: ', downloadQueue);
             var fileRef = downloadQueue.pop();
             if (!fileRef) {
                 showSuccess();
                 return
             }
             transferFile(fileRef).then(function () {
-                setTimeout(processQueue, 500)
+                setTimeout(processQueue, 500);
             }).catch(function (error) {
                 console.error('Failed to download file: ', error);
                 showError('Error! Could not download file(s)');
@@ -272,18 +272,18 @@ $(document).ready(function() {
     function transferFile(fileRef) {
         console.log('starting file download for ' + fileRef)
         if (window.downloadWithServiceWorker) {
-            var download = window.downloadWithServiceWorker(fileRef)
-            showProgressBar(download, download.promise)
-            return download.promise
+            var download = window.downloadWithServiceWorker(fileRef);
+            showProgressBar(download, download.promise);
+            return download.promise;
         } else {
-            showProgressBar(fileRef, fileRef.fetch())
+            showProgressBar(fileRef, fileRef.fetch());
             return fileRef.fetch().then(function (file) {
                 var anchor = document.createElement('a');
                 anchor.download = file.name;
                 anchor.href = URL.createObjectURL(file);
                 document.body.appendChild(anchor);
                 anchor.click();
-                return file
+                return file;
             })
         }
     }

--- a/downloadproxy.js
+++ b/downloadproxy.js
@@ -1,0 +1,105 @@
+
+const TRANSFER_START_TIMEOUT_MS = 10000
+const PERCENT_ENCODE_REGEX = /[\x00-\x20<=>*,/:;?{}@[\\\]"'()\x7f]/g
+
+let transfers = new Map()
+
+this.addEventListener('fetch', event => {
+  let {request} = event
+  if (!request.url.startsWith(registration.scope)) {
+    return
+  }
+  let path = request.url.slice(registration.scope.length)
+  if (!path.startsWith('intercept-download/')) {
+    return
+  }
+
+  let transferId = path.slice('intercept-download/'.length)
+  let transfer = transfers.get(transferId)
+  if (!transfer) {
+    console.error(`got download request for missing transfer id '${transferId}'`)
+    event.respondWith(new Response("", {
+      headers: {
+        'Content-Type': 'application/octet-stream',
+        'Content-Disposition': `attachment; filename*=UTF-8''download%20error`,
+      },
+    }))
+    return
+  }
+
+  transfers.delete(transferId)
+  console.log(`got download request for id=${transferId}, name=${transfer.name}, bytes=${transfer.size}`)
+
+  clearTimeout(transfer.startTimeoutId)
+  delete transfer.startTimeoutId
+
+  let encodedName = encodeURIComponent(transfer.name).replace(PERCENT_ENCODE_REGEX, char => {
+    var hex = char.charCodeAt(0).toString(16).toUpperCase()
+    return hex.length === 1 ? '%0' + hex : '%' + hex
+  })
+
+  event.respondWith(new Response(transfer.stream, {headers: {
+    'Content-Type': 'application/octet-stream',
+    'Content-Disposition': `attachment; filename*=UTF-8''${encodedName}`,
+    'Content-Length': transfer.size,
+  }}))
+})
+
+this.addEventListener('message', event => {
+  console.log(`got event with type ${event.data.type}`)
+  if (event.data.type === 'start-download') {
+    event.waitUntil(startDownload(event.data, event.ports))
+  }
+})
+
+function startDownload({name, size}, [port]) {
+  return new Promise((resolve, reject) => {
+    var transferId
+    do {
+      transferId = Math.random().toString(36).slice(2)
+    } while (transfers.has(transferId))
+
+    let url = `${registration.scope}intercept-download/${transferId}`
+    console.log(`got transfer of '${name}', ${size}bytes, with ${url}`)
+    port.postMessage({url})
+
+    let stream = new ReadableStream({
+      start(controller) {
+        port.onmessage = ({data}) => {
+          if (data.type === 'done') {
+            controller.close()
+            port.onmessage = null
+            resolve()
+          } else if (data.type === 'error') {
+            let msg = `Download failed, ${data.error.name}: ${data.error.message}`
+            console.error(msg)
+            port.onmessage = null
+            let error = new Error(msg)
+            error.name = 'DownloadError'
+            controller.error(error)
+            reject(error)
+          } else if (data.type === 'chunk') {
+            let chunk = new Uint8Array(data.chunk)
+            controller.enqueue(chunk)
+          } else {
+            console.error('transfer port received unknown message:', data)
+          }
+        }
+      },
+      cancel() {
+        console.log("Stream aborted")
+        transfers.delete(transferId)
+      },
+    })
+
+    let transfer = {transferId, port, name, size, stream}
+    transfers.set(transferId, transfer)
+
+    transfer.startTimeoutId = setTimeout(() => {
+      transfers.delete(transferId)
+      transfer.stream.cancel()
+      transfer.stream = null
+      port.onmessage = null
+    }, TRANSFER_START_TIMEOUT_MS)
+  })
+}

--- a/index.html
+++ b/index.html
@@ -65,19 +65,17 @@
                 </div>
                 <div class="box__error">
                     <img src="resources/img/red.png" />
-                    <p>
-                        Error! Could not transfer file(s)
-                    </p>
+                    <p class='box__error__message'></p>
                 </div>
 
                 <div id="box__progress">
                     <p>Transferring file(s)</p>
                 </div>
             </div>
-            <p id="isConnected">disconnected</p>
+            <p id="isConnected">Not connected</p>
         </div>
         <p class="contact">
-            Drop only works in Chrome and Firefox. For support and feedback, please
+            Drop only works in Chrome and Firefox, and only Chrome supports files above ~500MB. For support and feedback, please
             visit <a href="https://spaces.ericsson.net/room/!dqxyodhOSaYAOPlbfU:spaces.ericsson.net" target="_blank">Spaces</a>.
         </p>
       </section>

--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
                         Note! Your browser needs to be open while the files are transferred.
                     </p>
                 </div>
+                <button class="box__button" type="button" hidden="true">Send file(s)</button>
                 <div class="box__share">Share</div>
                 <div class="box__success">
                     <img src="resources/img/green.png" />

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
     <link rel="icon" href="resources/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="resources/style.css">
-    <script type="text/javascript" src="https://get.cct.ericsson.net/latest/cct.js"></script>
+    <script type="text/javascript" src="https://get.cct.ericsson.net/tag/v0.17.0-rc1/cct.js"></script>
     <script type="text/javascript" src="https://code.jquery.com/jquery-2.2.1.min.js"></script>
     <script type="text/javascript" src="utils.js"></script>
     <script type="text/javascript" src="app.js"></script>

--- a/resources/style.css
+++ b/resources/style.css
@@ -48,7 +48,7 @@ a:hover {
 .box {
     text-align: center;
     padding: 40px;
-    padding-top: 80px;
+    padding-top: 40px;
     width: 50%;
     min-height: 240px;
     margin-left: auto;
@@ -79,6 +79,9 @@ a:hover {
 }
 .box__error {
     color: #FF4949;
+}
+.box__instructions {
+    margin-top: 20px;
 }
 .box__note {
     font-size: 40%;

--- a/resources/style.css
+++ b/resources/style.css
@@ -71,6 +71,8 @@ a:hover {
 .box__share {
     font-size: 50%;
     margin-top: 20px;
+    user-select: all;
+    -moz-user-select: all;
 }
 .box__success {
     color: #06B906;

--- a/utils.js
+++ b/utils.js
@@ -62,62 +62,62 @@ function connectClient(client) {
     return cct.Auth.anonymous({
         iceServers: EXAMPLE_UTILS_ICE_SERVERS,
         serverUrl: SERVER_URL
-    }).then(client.auth)
+    }).then(client.auth);
 }
 
 function enterRoom(roomLocalId, client) {
     if (roomLocalId) {
         var roomId = '!' + roomLocalId + ':' + client.authInfo.serverName;
-        console.log('Joining existing room ' + roomId)
+        console.log('Joining existing room ' + roomId);
         return client.getRoom(roomId).join();
     } else {
         console.log('Creating a new room');
-        return client.createRoom({joinRule: 'open'})
+        return client.createRoom({joinRule: 'open'});
     }
 }
 
 if (navigator.serviceWorker && ReadableStream) {
   navigator.serviceWorker.register('/downloadproxy.js').then(function (registration) {
-    window.registration = registration
-    console.log('Registered service worker')
+    window.registration = registration;
+    console.log('Registered service worker');
     return navigator.serviceWorker.ready;
   }).then(function () {
-    console.log('Service worker is ready')
+    console.log('Service worker is ready');
     window.downloadWithServiceWorker = function (fileRef) {
-        var channel = new MessageChannel()
-        var port = channel.port1
+        var channel = new MessageChannel();
+        var port = channel.port1;
 
         port.onmessage = function (event) {
             var anchor = document.createElement('a');
             anchor.href = event.data.url;
             anchor.click();
-            port.onmessage = null
+            port.onmessage = null;
         }
 
         navigator.serviceWorker.controller.postMessage({
             type: 'start-download',
             name: fileRef.name,
             size: fileRef.size,
-        }, [channel.port2])
+        }, [channel.port2]);
 
-        var stream = fileRef.stream()
+        var stream = fileRef.stream();
 
         stream.on('chunk', function (chunk) {
             port.postMessage({
                 type: 'chunk',
                 chunk: chunk,
-            })
+            });
         })
 
         stream.promise.then(function () {
-            port.postMessage({type: 'done'})
+            port.postMessage({type: 'done'});
         })
 
         stream.promise.catch(function (error) {
-            port.postMessage({type: 'error', error: error})
+            port.postMessage({type: 'error', error: error});
         })
 
-        return stream
+        return stream;
     }
   }).catch(function (error) {
     console.error('ServiceWorker registration failed: ', error);

--- a/utils.js
+++ b/utils.js
@@ -16,195 +16,7 @@
 
 'use strict';
 
-function Peer2Peer(opts) {
-    this.session = opts.session || '';
-    this.client = opts.client || '';
-    this.room = null;
-    this.hash = '';
-
-    this._setupRoom = this._setupRoom.bind(this);
-    this._identifySession = this._onIdentifySession.bind(this);
-    this._onRoomCreated = this._onRoomCreated.bind(this);
-}
-Peer2Peer.prototype = {
-    constructor: Peer2Peer,
-
-    _setupRoom: function (test) {
-        if (this.session) {
-            return this.client.fetchRoomById(this.session)
-                .then(function (room) {
-                    return room.join();
-                }, function (error) {
-                    logError('Failed to fetch room!', error);
-                });
-        } else {
-            console.log('Creating a room');
-            return this.client.createRoom({
-                joinRule: 'open',
-                powerLevels: cct.PowerLevelsEdit.fromDefault(this.client.user)
-                    .addState(0)
-                    .userDefault(100)
-                    .eventDefault(0)
-                    .event('cct.room.data.share', 0),
-            });
-        }
-    },
-
-    _onIdentifySession: function () {
-        this.hash = window.location.hash;
-        if (this.hash) {
-            this.session = this.hash.slice(1);
-            console.log('Assigned sessionId:', this.session);
-        }
-    },
-
-    _onRoomCreated: function (room) {
-        this.room = room;
-        window.location.hash = this.room.id;
-        return this;
-    },
-};
-
-Peer2Peer.prototype.start = function (client) {
-    return cct.Auth.anonymous({serverUrl: getCctAddress()})
-        .then(this.client.auth, function (error) {
-            cct.log.error('error', error);
-            logError('Failed to authenticate client');
-            throw error;
-        })
-        .then(this._identifySession)
-        .then(this._setupRoom)
-        .then(this._onRoomCreated)
-        .catch(function (error) {
-            cct.log.error('error', error);
-            logError('Failed to setup call');
-        });
-};
-
-Peer2Peer.prototype.setupCall = function () {
-    var members = this.room.otherMembers.slice();
-    members.sort(function (a, b) {
-        return b.lastActive - a.lastActive;
-    });
-    return this.room.startCall(members[0]);
-};
-
-var body = document.getElementsByTagName('body');
-
-function toggleLog() { // eslint-disable-line no-unused-vars
-    console.log('WARNING! No visible log implemented.');
-    return;
-    /*
-    var toggleLog = document.getElementById('toggleLog');
-    var footer = document.getElementById('footer');
-    if (toggleLog.value === 'show log') {
-        footer.style.height = '500px';
-        toggleLog.value = 'hide log';
-
-        setTimeout(function () {
-            var counter = 0;
-            var scrollDown = setInterval(function () {
-                body[0].scrollTop += 25;
-                counter++;
-                if (counter > 20) {
-                    clearInterval(scrollDown);
-                }
-            }, 5);
-        }, 30);
-    } else {
-        footer.style.height = '';
-        toggleLog.value = 'show log';
-    }
-    */
-}
-
-function showLog() {
-    console.log('WARNING! No visible log implemented.');
-    return;
-    /*
-    var toggleLog = document.getElementById('toggleLog');
-    var footer = document.getElementById('footer');
-    if (toggleLog.value === 'show log') {
-        footer.style.height = '500px';
-        toggleLog.value = 'hide log';
-    }
-    */
-}
-
-function clientsInARoom(url, count) { // eslint-disable-line no-unused-vars
-    if (!count) {
-        count = 2;
-    }
-
-    var clients = [];
-    for (var i = 0; i < count; i++) {
-        clients[i] = new cct.Client();
-    }
-
-    return Promise.all(clients.map(function (client) {
-        return cct.Auth.anonymous({serverUrl: url}).then(client.auth);
-    })).then(function (clients) {
-        var rest = clients.slice(0, -1);
-        return Promise.all(rest.map(function (client) {
-            return client.once('invite').then(function (room) {
-                return room.join();
-            });
-        }).concat(clients[clients.length - 1].createRoom({
-            invite: rest.map(function (client) {
-                return client.user;
-            }),
-        }))).then(function (rooms) {
-            return {
-                rooms: rooms,
-                clients: clients,
-            };
-        });
-    });
-}
-
-function logP(label) { // eslint-disable-line no-unused-vars
-    return function (ret) {
-        log(label, ret);
-        return ret;
-    };
-}
-
-function logPE(label) { // eslint-disable-line no-unused-vars
-    return function (ret) {
-        log(label + ' error', ret);
-        showLog();
-        throw ret;
-    };
-}
-
-function log(label, ret) {
-    var div = document.createElement('div');
-    var tag = document.createElement('div');
-    var content = document.createElement('pre');
-    var str = ret;
-    if (typeof (str) !== 'string') {
-        str = JSON.stringify(str, null, '\u00a0\u00a0\u00a0\u00a0');
-    }
-    str = str.replace(/(?:\\r)?\\n/g, '\n');
-    tag.textContent = label;
-    content.textContent = str;
-    console.log(label + ': ' + str);
-    div.appendChild(tag);
-    div.appendChild(content);
-    if (document.getElementById('log')) {
-        document.getElementById('log').appendChild(div);
-    }
-    return ret;
-}
-
-function logError(ret) {
-    log('error', ret);
-    showLog();
-}
-
-function getCctAddress() { // eslint-disable-line no-unused-vars
-    return 'https://demo.c3.ericsson.net';
-}
+var SERVER_URL = 'https://demo.c3.ericsson.net'
 
 var EXAMPLE_UTILS_ICE_SERVERS = [ // eslint-disable-line no-unused-vars
     {
@@ -245,3 +57,20 @@ var EXAMPLE_UTILS_ICE_SERVERS = [ // eslint-disable-line no-unused-vars
         username: '28224511:1379330808'
     }
 ];
+
+function connectClient(client) {
+    return cct.Auth.anonymous({
+        iceServers: EXAMPLE_UTILS_ICE_SERVERS,
+        serverUrl: SERVER_URL
+    }).then(client.auth)
+}
+
+function enterRoom(roomId) {
+    if (roomId) {
+        console.log('Joining existing room ' + roomId)
+        return client.getRoom(roomId).join();
+    } else {
+        console.log('Creating a new room');
+        return client.createRoom({joinRule: 'open'})
+    }
+}

--- a/utils.js
+++ b/utils.js
@@ -65,8 +65,9 @@ function connectClient(client) {
     }).then(client.auth)
 }
 
-function enterRoom(roomId) {
-    if (roomId) {
+function enterRoom(roomLocalId, client) {
+    if (roomLocalId) {
+        var roomId = '!' + roomLocalId + ':' + client.authInfo.serverName;
         console.log('Joining existing room ' + roomId)
         return client.getRoom(roomId).join();
     } else {


### PR DESCRIPTION
This upgrades to libcct v0.17.0-rc1, which has a ton of improvements for file transfers.

It also uses a service worker to stream file downloads in Chrome, making it possible to transfer huge files.

`Firefox <-> Firefox` can still only handle small-ish files, around a couple of hundred MB, and is also a bit slower than Chrome.
The transfer speed `Chrome <-> Chrome` seems to be limited by file access in Chrome. The data channels are at least able to do 12MB/s+
`Firefox <-> Chrome` and `Chrome <-> Firefox` has some issues, large files downloads tend to just hang a couple of hundred MB in, which then causes a timeout error. This seems to be an interop problem, since I also saw some other weird behaviour that only happened between Firefox and Chrome. Still works for small files, ~100MB.